### PR TITLE
chore: add self-hosted pr action

### DIFF
--- a/.github/workflows/pr-self-hosted.yml
+++ b/.github/workflows/pr-self-hosted.yml
@@ -1,0 +1,17 @@
+name: PR-self-hosted
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ['self-hosted', 'amd64', 'noble']
+    name: CI Build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+      - run: ./gradlew build --no-daemon


### PR DESCRIPTION
This PR enabled self-hosted PR action. 
The action is configured as a new file in order to avoid merge conflicts when syncing the fork.