### PR TITLE
feat: add rockcraft command to enable rockcraft plugin in maven/gradle projects

### DIFF
--- a/src/main/java/com/canonical/devpackspring/rewrite/AddRockcraftGradleRecipe.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/AddRockcraftGradleRecipe.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite;
+
+import com.canonical.devpackspring.rewrite.visitors.GroovyAddPluginVisitor;
+import com.canonical.devpackspring.rewrite.visitors.KotlinAddPluginVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+public class AddRockcraftGradleRecipe extends Recipe {
+
+	private final String PLUGIN_ID = "io.github.rockcrafters.rockcraft";
+
+	private final String PLUGIN_VERSION = "1.0.0";
+
+	private final TreeVisitor<?, ExecutionContext> visitor;
+
+	public AddRockcraftGradleRecipe(boolean kotlin) {
+		if (kotlin) {
+			visitor = new KotlinAddPluginVisitor(PLUGIN_ID, PLUGIN_VERSION);
+		}
+		else {
+			visitor = new GroovyAddPluginVisitor(PLUGIN_ID, PLUGIN_VERSION);
+		}
+	}
+
+	@Override
+	public @NlsRewrite.DisplayName String getDisplayName() {
+		return "Add rockcraft support";
+	}
+
+	@Override
+	public @NlsRewrite.Description String getDescription() {
+		return "Add rockcraft plugin support to the project";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return visitor;
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/rewrite/AddRockcraftMavenRecipe.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/AddRockcraftMavenRecipe.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite;
+
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.Recipe;
+import org.openrewrite.RecipeList;
+import org.openrewrite.maven.AddPlugin;
+
+public class AddRockcraftMavenRecipe extends Recipe {
+
+	@Override
+	public @NlsRewrite.DisplayName String getDisplayName() {
+		return "Add rockcraft maven plugin";
+	}
+
+	@Override
+	public @NlsRewrite.Description String getDescription() {
+		return "Adds rockcraft maven plugin";
+	}
+
+	@Override
+	public void buildRecipeList(RecipeList recipes) {
+		super.buildRecipeList(recipes);
+		// CHECKSTYLE.OFF: SpringLeadingWhitespace - maven executions snippets format
+		recipes.recipe(new AddPlugin("io.github.rockcrafters", "rockcraft-maven-plugin", "1.0.0", null, null, """
+					<executions>
+						<execution>
+							<goals>
+								<!-- creates rockcraft.yaml -->
+								<goal>create-rock</goal>
+								<!-- builds rock image -->
+								<goal>build-rock</goal>
+								<!-- pushes rock to the local docker daemon-->
+								<goal>push-rock</goal>
+							</goals>
+						</execution>
+					</executions>
+				""", null));
+		// CHECKSTYLE.ON: SpringLeadingWhitespace
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/rewrite/EnableRockcraftRefactoring.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/EnableRockcraftRefactoring.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.gradle.GradleParser;
+import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.maven.MavenParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EnableRockcraftRefactoring {
+
+	private static final Logger logger = LoggerFactory.getLogger(EnableRockcraftRefactoring.class);
+
+	public EnableRockcraftRefactoring() {
+	}
+
+	public boolean execute(Path baseDir) throws IOException {
+		InMemoryExecutionContext context = new InMemoryExecutionContext(new Consumer<Throwable>() {
+			@Override
+			public void accept(Throwable throwable) {
+				logger.error(throwable.getMessage(), throwable);
+			}
+		});
+
+		List<SourceFile> files = parseGradle(baseDir, context);
+		if (!files.isEmpty()) {
+			boolean kotlinDsl = files.stream()
+				.filter(x -> x.getSourcePath().toString().equals("build.gradle"))
+				.findAny()
+				.isEmpty();
+			return RecipeUtil.applyRecipe(baseDir, new AddRockcraftGradleRecipe(kotlinDsl), files, context);
+		}
+		files = parseMaven(baseDir, context);
+		return RecipeUtil.applyRecipe(baseDir, new AddRockcraftMavenRecipe(), files, context);
+	}
+
+	private static List<SourceFile> parseMaven(Path baseDir, InMemoryExecutionContext context) {
+		Parser p = MavenParser.builder().build();
+		List<Path> files = Arrays.stream(baseDir.toFile().listFiles(file -> "pom.xml".equals(file.getName())))
+			.map(x -> x.toPath())
+			.toList();
+
+		return p.parse(files, baseDir, context).toList();
+	}
+
+	private static List<SourceFile> parseGradle(Path baseDir, InMemoryExecutionContext context) {
+		Parser.Builder builder = GradleParser.builder()
+			.groovyParser(GroovyParser.builder().logCompilationWarningsAndErrors(true))
+			.kotlinParser(KotlinParser.builder().logCompilationWarningsAndErrors(true));
+
+		Parser p = builder.build();
+		final HashSet<String> gradleNames = new HashSet<>(Arrays.asList("build.gradle", "build.gradle.kts",
+				"settings.gradle", "settings.gradle.kts", "init.gradle", "init.gradle.kts"));
+		List<Path> files = Arrays.stream(baseDir.toFile().listFiles(file -> gradleNames.contains(file.getName())))
+			.map(x -> x.toPath())
+			.toList();
+
+		return p.parse(files, baseDir, context).toList();
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/rewrite/RecipeUtil.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/RecipeUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.RecipeRun;
+import org.openrewrite.Result;
+import org.openrewrite.SourceFile;
+import org.openrewrite.internal.InMemoryLargeSourceSet;
+
+public abstract class RecipeUtil {
+
+	public static boolean applyRecipe(Path baseDir, Recipe r, List<SourceFile> sourceFiles, ExecutionContext context)
+			throws IOException {
+		RecipeRun run = r.run(new InMemoryLargeSourceSet(sourceFiles), context);
+		List<Result> results = run.getChangeset().getAllResults();
+		for (Result result : results) {
+			SourceFile after = result.getAfter();
+			Files.writeString(baseDir.resolve(after.getSourcePath()), result.getAfter().printAll());
+		}
+		return !results.isEmpty();
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/rewrite/StatementUtil.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/StatementUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+
+public abstract class StatementUtil {
+
+	public static List<Statement> append(List<Statement> existingStatements, List<Statement> templateStatements) {
+		existingStatements.addAll(Arrays
+			.asList(templateStatements.stream().map(x -> x.withPrefix(Space.format("\n"))).toArray(Statement[]::new)));
+		return existingStatements;
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/rewrite/visitors/AddPluginVisitor.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/visitors/AddPluginVisitor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite.visitors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+
+public class AddPluginVisitor {
+
+	public static final String HAS_PLUGIN_BLOCK = "has_plugin_block";
+
+	public static final String METHOD_ID = "id";
+
+	public static final String METHOD_PLUGINS = "plugins";
+
+	public List<Statement> statements;
+
+	private final Set<String> appliedPlugins = new HashSet<>();
+
+	private final String pluginName;
+
+	public AddPluginVisitor(String pluginName, List<Statement> statements) {
+		this.pluginName = pluginName;
+		this.statements = statements;
+	}
+
+	public @Nullable J postVisit(@NonNull J tree, ExecutionContext executionContext,
+			BiFunction<J, ExecutionContext, J> action) {
+		if (tree instanceof J.MethodInvocation) {
+			J.MethodInvocation call = (J.MethodInvocation) tree;
+			if (METHOD_PLUGINS.equals(call.getSimpleName())) {
+				executionContext.putMessage(HAS_PLUGIN_BLOCK, true);
+				new JavaIsoVisitor<ExecutionContext>() {
+					@Override
+					public @NotNull J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+							ExecutionContext executionContext) {
+						if (METHOD_ID.equals(method.getSimpleName())) {
+							Expression pluginName = method.getArguments().get(0);
+							appliedPlugins.add(pluginName.toString());
+						}
+						return method;
+					}
+				}.visitMethodInvocation(call, executionContext);
+				if (appliedPlugins.contains(pluginName)) {
+					return tree;
+				}
+				return addPluginCall(executionContext, call);
+			}
+		}
+		return action.apply(tree, executionContext);
+	}
+
+	private J.@NotNull MethodInvocation addPluginCall(ExecutionContext executionContext, J.MethodInvocation call) {
+		J.Lambda lambda = (J.Lambda) call.getArguments().get(0);
+		J.Block block = (J.Block) lambda.getBody();
+
+		final Space prefix = block.getStatements().isEmpty() ? Space.format("\n\t")
+				: block.getStatements().get(0).getPrefix();
+		List<Statement> newStatements = new ArrayList<>();
+		newStatements.addAll(block.getStatements());
+		newStatements
+			.addAll(Arrays.asList(statements.stream().map(x -> x.withPrefix(prefix)).toArray(Statement[]::new)));
+
+		block = block.withStatements(newStatements);
+		lambda = lambda.withBody(block);
+		return call.withArguments(List.of(lambda));
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/rewrite/visitors/GroovyAddPluginVisitor.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/visitors/GroovyAddPluginVisitor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite.visitors;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import com.canonical.devpackspring.rewrite.StatementUtil;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.gradle.GradleParser;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+public class GroovyAddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
+
+	private final String pluginTemplateGroovy = "plugins {\n\tid '%s' version '%s'\n}\n";
+
+	private final AddPluginVisitor visitor;
+
+	private final SourceFile templateSource;
+
+	public GroovyAddPluginVisitor(String pluginName, String pluginVersion) {
+		Parser.Builder builder = GradleParser.builder()
+			.groovyParser(GroovyParser.builder().logCompilationWarningsAndErrors(true));
+		Parser parser = builder.build();
+		InMemoryExecutionContext context = new InMemoryExecutionContext();
+		templateSource = parser
+			.parseInputs(
+					Arrays.asList(Parser.Input.fromString(Paths.get("/tmp/build.gradle"),
+							String.format(pluginTemplateGroovy, pluginName, pluginVersion))),
+					Paths.get("/tmp"), context)
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
+
+		List<Statement> statements = ((G.CompilationUnit) templateSource).getStatements();
+		G.MethodInvocation stm = (G.MethodInvocation) statements.get(0);
+		G.Lambda lambda = (G.Lambda) stm.getArguments().get(0);
+		G.Block gBlock = (G.Block) lambda.getBody();
+		visitor = new AddPluginVisitor(pluginName, gBlock.getStatements());
+	}
+
+	@Override
+	public @Nullable J postVisit(@NonNull J tree, ExecutionContext executionContext) {
+		return visitor.postVisit(tree, executionContext, (t, context) -> {
+			if (Boolean.TRUE.equals(context.getMessage(AddPluginVisitor.HAS_PLUGIN_BLOCK))) {
+				return tree;
+			}
+			if (tree instanceof G.CompilationUnit unit) {
+				if (!unit.getSourcePath().toString().equals("build.gradle")) {
+					return tree;
+				}
+
+				List<Statement> statements = StatementUtil.append(unit.getStatements(),
+						((G.CompilationUnit) templateSource).getStatements());
+				return unit.withStatements(statements);
+			}
+			return tree;
+		});
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/rewrite/visitors/KotlinAddPluginVisitor.java
+++ b/src/main/java/com/canonical/devpackspring/rewrite/visitors/KotlinAddPluginVisitor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.rewrite.visitors;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import com.canonical.devpackspring.rewrite.StatementUtil;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.gradle.GradleParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.tree.K;
+
+public class KotlinAddPluginVisitor extends KotlinIsoVisitor<ExecutionContext> {
+
+	private final String pluginTemplateKotlin = "plugins {\n\tid(\"%s\") version \"%s\"\n}\n";
+
+	private final AddPluginVisitor visitor;
+
+	private final SourceFile templateSource;
+
+	public KotlinAddPluginVisitor(String pluginName, String pluginVersion) {
+		Parser.Builder builder = GradleParser.builder()
+			.kotlinParser(KotlinParser.builder().logCompilationWarningsAndErrors(true));
+		Parser parser = builder.build();
+		InMemoryExecutionContext context = new InMemoryExecutionContext();
+
+		templateSource = parser
+			.parseInputs(
+					Arrays.asList(Parser.Input.fromString(Paths.get("/tmp/build.gradle.kts"),
+							String.format(pluginTemplateKotlin, pluginName, pluginVersion))),
+					Paths.get("/tmp"), context)
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
+
+		List<Statement> statements = ((K.CompilationUnit) templateSource).getStatements();
+		J.Block block = (J.Block) statements.get(0);
+		K.MethodInvocation stm = (K.MethodInvocation) block.getStatements().get(0);
+		K.Lambda lambda = (K.Lambda) stm.getArguments().get(0);
+		K.Block kBlock = (K.Block) lambda.getBody();
+		visitor = new AddPluginVisitor(pluginName, kBlock.getStatements());
+	}
+
+	@Override
+	public @Nullable J postVisit(@NonNull J tree, ExecutionContext executionContext) {
+		return visitor.postVisit(tree, executionContext, (t, context) -> {
+			if (Boolean.TRUE.equals(context.getMessage(AddPluginVisitor.HAS_PLUGIN_BLOCK))) {
+				return tree;
+			}
+
+			if (tree instanceof K.CompilationUnit unit) {
+				if (!unit.getSourcePath().toString().equals("build.gradle.kts")) {
+					return tree;
+				}
+				List<Statement> statements = StatementUtil.append(unit.getStatements(),
+						((K.CompilationUnit) templateSource).getStatements());
+				return unit.withStatements(statements);
+			}
+			return t;
+		});
+	}
+
+}

--- a/src/main/java/org/springframework/cli/command/RockcraftCommands.java
+++ b/src/main/java/org/springframework/cli/command/RockcraftCommands.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cli.command;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.canonical.devpackspring.rewrite.EnableRockcraftRefactoring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cli.util.IoUtils;
+import org.springframework.cli.util.TerminalMessage;
+import org.springframework.shell.command.annotation.Command;
+import org.springframework.shell.command.annotation.Option;
+
+@Command(command = "rockcraft", group = "Devpack")
+public class RockcraftCommands {
+
+	private final TerminalMessage terminalMessage;
+
+	private final Path workingDir;
+
+	private final EnableRockcraftRefactoring rockcraftService = new EnableRockcraftRefactoring();
+
+	@Autowired
+	public RockcraftCommands(TerminalMessage terminalMessage) {
+		this.terminalMessage = terminalMessage;
+		this.workingDir = IoUtils.getWorkingDirectory();
+	}
+
+	public RockcraftCommands(TerminalMessage terminalMessage, Path workingDir) {
+		this.terminalMessage = terminalMessage;
+		this.workingDir = workingDir;
+	}
+
+	@Command(command = "add", description = "Add rockcraft export plugin for the project")
+	public String addRockcraft(@Option(description = "Project path") String path) throws IOException {
+		Path where = (path != null) ? Path.of(path) : workingDir;
+		if (rockcraftService.execute(where)) {
+			return "Added rockcraft plugin to " + path;
+		}
+		return "Project unchanged.";
+	}
+
+	@Command(command = "export-rock", description = "Export rock runtime image")
+	public String exportRock() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Command(command = "export-build-rock", description = "Export rock build and test image")
+	public String exportBuildRock() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+}

--- a/src/test/java/org/springframework/cli/command/RockcraftCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/RockcraftCommandsTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cli.command;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cli.support.CommandRunner;
+import org.springframework.cli.support.MockConfigurations;
+import org.springframework.cli.util.StubTerminalMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RockcraftCommandsTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(MockConfigurations.MockBaseConfig.class);
+
+	@Test
+	public void testAddRockcraftKotlin(final @TempDir Path workingDir) {
+		testAddRockcraft("gradle-kotlin", workingDir, new String[] { "./gradlew", "clean" });
+	}
+
+	@Test
+	public void testAddRockcraftGradle(final @TempDir Path workingDir) {
+		testAddRockcraft("gradle-groovy", workingDir, new String[] { "./gradlew", "clean" });
+	}
+
+	@Test
+	public void testAddRockcraftMaven(final @TempDir Path workingDir) {
+		testAddRockcraft("rest-service", workingDir, new String[] { "mvn", "clean" });
+	}
+
+	public void testAddRockcraft(String project, final @TempDir Path workingDir, String[] checkCommand) {
+		this.contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run((context) -> {
+
+			StubTerminalMessage terminalMessage = new StubTerminalMessage();
+			RockcraftCommands commands = new RockcraftCommands(terminalMessage, workingDir);
+			CommandRunner commandRunner = new CommandRunner.Builder(context).prepareProject(project, workingDir)
+				.build();
+			commandRunner.run();
+			String expected = commands.addRockcraft(workingDir.toString());
+			assertThat(expected).isEqualTo("Added rockcraft plugin to " + workingDir);
+			Process proc = new ProcessBuilder().command(checkCommand)
+				.inheritIO()
+				.directory(workingDir.toFile())
+				.start();
+			int exit = proc.waitFor();
+			assertThat(exit).isEqualTo(0);
+		});
+	}
+
+}


### PR DESCRIPTION
This is initial PR to add rockcraft support. 

The code uses openrewrite to refactor build files to include rockcraft plugin. 
The name/version are hardcoded in the first implementation.

Changes:
 - added RockcraftCommand that call into EnableRockcraftRefactoring. 
 - EnableRockcraftRefactoring applies "add build plugin" refactoring. 
 - Gradle refactorings are bugged in openrewrite (e.g. plugin section is being added both to build.gradle and settings.gradle) and support only Gradle  DSL, so I have added new recipes for those. 
 - Maven recipe uses stock AddPlugin recipe.

 
