### PR TITLE
feat: execute build plugins using spring cli

### DIFF
--- a/.github/workflows/pr-self-hosted.yml
+++ b/.github/workflows/pr-self-hosted.yml
@@ -19,6 +19,14 @@ jobs:
           java-version: 17
           cache: gradle
       - run: sudo apt-get -y --update install maven
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+          channel: 5.21/candidate
+      - name: Setup rockcraft
+        run: |
+          rm -rf /home/runner/.local/state/rockcraft/log/*
+          sudo snap install rockcraft --classic
       - run: ./gradlew build -PexcludeTags=boot,maven-modification,maven-dependency --no-daemon --stacktrace
       - name: Store reports
         if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ repositories {
 	if (version.endsWith('-SNAPSHOT')) {
 		maven { url "https://repo.spring.io/snapshot" }
 	}
+	// +dependencies for canonical snap
+	maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+	// -dependencies for canonical snap
 }
 
 ext {
@@ -99,6 +102,7 @@ dependencies {
 	implementation "org.openrewrite:rewrite-kotlin:${openrewriteVersion}"
 	implementation "org.eclipse.jgit:org.eclipse.jgit:7.2.0.202503040940-r"
 	implementation "org.codehaus.groovy:groovy-all:3.0.24"
+	implementation "org.gradle:gradle-tooling-api:8.9"
 	// -dependencies for canonical snap
 
 	testImplementation 'org.openrewrite:rewrite-test'

--- a/src/main/java/com/canonical/devpackspring/build/GradleRunner.java
+++ b/src/main/java/com/canonical/devpackspring/build/GradleRunner.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.build;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.gradle.tooling.BuildLauncher;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector;
+import org.jline.utils.AttributedStyle;
+
+import org.springframework.cli.util.TerminalMessage;
+
+public abstract class GradleRunner {
+
+	private static final String GRADLE_VERSION = "8.13";
+
+	public static boolean run(Path baseDir, PluginDescriptor desc, String task, TerminalMessage message)
+			throws IOException {
+		OutputStream terminalStream = new TerminalOutputStream(message, new AttributedStyle().foregroundDefault());
+		OutputStream terminalStreamError = new TerminalOutputStream(message,
+				new AttributedStyle().foreground(AttributedStyle.RED));
+
+		if (task == null) {
+			task = desc.defaultTask();
+		}
+		Path initScript = null;
+		try {
+			initScript = Files.createTempFile("init", ".gradle.kts");
+			writeTemporaryInitFile(initScript, desc);
+
+			DefaultGradleConnector connector = (DefaultGradleConnector) GradleConnector.newConnector();
+			if (Files.exists(baseDir.resolve("gradle/wrapper/gradle-wrapper.properties"))) {
+				connector.useBuildDistribution();
+			}
+			else {
+				connector.useGradleVersion(GRADLE_VERSION);
+			}
+			try (ProjectConnection connection = connector.forProjectDirectory(baseDir.toFile()).connect()) {
+				BuildLauncher buildLauncher = connection.newBuild()
+					.setStandardOutput(terminalStream)
+					.setStandardError(terminalStreamError)
+					.addArguments("--init-script", initScript.toString(), task)
+					.forTasks(task);
+				buildLauncher.run();
+				return true;
+			}
+		}
+		catch (RuntimeException ex) {
+			try (PrintStream ps = new PrintStream(terminalStreamError)) {
+				// skip runtime exception itself - it only prints
+				// that task execution failed
+				ps.print(ex.getCause().getMessage());
+			}
+			return false;
+		}
+		finally {
+			if (initScript != null) {
+				Files.deleteIfExists(initScript);
+			}
+		}
+	}
+
+	private static void writeTemporaryInitFile(Path file, PluginDescriptor desc) throws IOException {
+		StringBuilder template = new StringBuilder();
+
+		if (desc.repository() != null) {
+			StringBuilder dependencies = new StringBuilder();
+			readTemplate(dependencies, "/com/canonical/devpackspring/apply-plugin-deps.gradle.kts");
+			template.append(String.format(dependencies.toString(), desc.repository(), desc.classpath()));
+		}
+
+		readTemplate(template, "/com/canonical/devpackspring/apply-plugin.gradle.kts");
+		Files.writeString(file, String.format(template.toString(), desc.id(), desc.className(), desc.id(),
+				(desc.defaultConfiguration() != null) ? desc.defaultConfiguration() : ""));
+	}
+
+	private static void readTemplate(StringBuilder template, String source) throws IOException {
+		try (BufferedReader r = new BufferedReader(
+				new InputStreamReader(GradleRunner.class.getResourceAsStream(source)))) {
+			String line;
+			while ((line = r.readLine()) != null) {
+				template.append(line);
+				template.append(System.lineSeparator());
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/build/MavenRunner.java
+++ b/src/main/java/com/canonical/devpackspring/build/MavenRunner.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.build;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+import org.springframework.cli.util.TerminalMessage;
+
+public abstract class MavenRunner {
+
+	public static boolean run(Path baseDir, PluginDescriptor plugin, String goal, TerminalMessage message)
+			throws IOException {
+		String command = "mvn";
+		if (Files.exists(baseDir.resolve("mvnw")) && validWrapper(baseDir)) {
+			command = "./mvnw";
+		}
+
+		if (goal == null) {
+			goal = plugin.defaultTask();
+		}
+
+		String pluginId = plugin.id() + ":" + plugin.version();
+		ArrayList<String> args = new ArrayList<>();
+		args.add(command);
+		StringTokenizer tk = new StringTokenizer(goal, " ");
+		while (tk.hasMoreTokens()) {
+			String arg = tk.nextToken();
+			if (arg.startsWith(":")) {
+				arg = pluginId + arg;
+			}
+			args.add(arg);
+		}
+
+		ProcessBuilder pb = new ProcessBuilder().command(args).directory(baseDir.toFile());
+		return ProcessUtil.runProcess(message, pb) == 0;
+	}
+
+	private static boolean validWrapper(Path dir) throws IOException {
+		Process p = new ProcessBuilder().command("./mvnw", "-version").directory(dir.toFile()).start();
+		try {
+			int ret = p.waitFor();
+			return ret == 0;
+		}
+		catch (InterruptedException ex) {
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/build/PluginRunner.java
+++ b/src/main/java/com/canonical/devpackspring/build/PluginRunner.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.build;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.springframework.cli.util.TerminalMessage;
+
+public class PluginRunner {
+
+	private Path workDir;
+
+	private static final String[] GRADLE_FILES = new String[] { "build.gradle", "build.gradle.kts" };
+
+	private static final String[] MAVEN_FILES = new String[] { "pom.xml" };
+
+	public PluginRunner(Path workDir) {
+		this.workDir = workDir;
+	}
+
+	public BuildSystem detectBuildSystem() {
+		for (var file : GRADLE_FILES) {
+			if (Files.exists(workDir.resolve(file))) {
+				return BuildSystem.gradle;
+			}
+		}
+		for (var file : MAVEN_FILES) {
+			if (Files.exists(workDir.resolve(file))) {
+				return BuildSystem.maven;
+			}
+		}
+		return BuildSystem.unknown;
+	}
+
+	public boolean run(BuildSystem buildSystem, PluginDescriptor desc, String command, TerminalMessage message)
+			throws IOException {
+		switch (buildSystem) {
+			case gradle:
+				return GradleRunner.run(workDir, desc, command, message);
+			case maven:
+				return MavenRunner.run(workDir, desc, command, message);
+			default:
+				throw new IllegalArgumentException("Unknown build system - neither Maven or Gradle detected.\n");
+		}
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/build/ProcessUtil.java
+++ b/src/main/java/com/canonical/devpackspring/build/ProcessUtil.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.build;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+
+import org.springframework.cli.util.TerminalMessage;
+
+/**
+ * Runs process and sends output to TerminalMessage
+ */
+public abstract class ProcessUtil {
+
+	/**
+	 * Starts the process and outputs to the provided terminal message
+	 * @param message - TerminalMessage
+	 * @param pb - ProcessBuilder
+	 * @return process execution error code
+	 * @throws IOException - unable to start the process
+	 */
+	public static int runProcess(final TerminalMessage message, ProcessBuilder pb) throws IOException {
+		final Process p = pb.start();
+
+		Thread stdout = new Thread(() -> {
+			AttributedStyle style = new AttributedStyle().foregroundDefault();
+			try (BufferedReader r = p.inputReader()) {
+				readOutput(r, message, style);
+			}
+			catch (IOException ex) {
+				throw new RuntimeException(ex);
+			}
+		});
+		stdout.start();
+
+		Thread stderr = new Thread(() -> {
+			AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
+			try (BufferedReader r = p.errorReader()) {
+				readOutput(r, message, style);
+			}
+			catch (IOException ex) {
+				throw new RuntimeException(ex);
+			}
+		});
+		stderr.start();
+
+		int ret;
+		try {
+			ret = p.waitFor();
+		}
+		catch (InterruptedException ex) {
+			ret = -1;
+		}
+
+		try {
+			stderr.join();
+		}
+		catch (InterruptedException ex) {
+			// ignore the exception
+		}
+		try {
+			stdout.join();
+		}
+		catch (InterruptedException ex) {
+			// ignore the exception
+		}
+
+		return ret;
+	}
+
+	private static void readOutput(BufferedReader r, TerminalMessage message, AttributedStyle style)
+			throws IOException {
+		String line;
+		while ((line = r.readLine()) != null) {
+			message.print(new AttributedString(line, style));
+		}
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/build/TerminalOutputStream.java
+++ b/src/main/java/com/canonical/devpackspring/build/TerminalOutputStream.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.build;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+
+import org.springframework.cli.util.TerminalMessage;
+
+/**
+ * Outputs messages to the TerminalMessage using specified style
+ */
+public class TerminalOutputStream extends OutputStream {
+
+	private TerminalMessage message;
+
+	private AttributedStyle style;
+
+	private StringBuilder buffer;
+
+	public TerminalOutputStream(TerminalMessage message, AttributedStyle style) {
+		this.message = message;
+		this.style = style;
+		this.buffer = new StringBuilder();
+	}
+
+	@Override
+	public void write(int i) throws IOException {
+		String s = Character.toString(i);
+		if (s.equals(System.lineSeparator())) {
+			flushInternal();
+		}
+		else {
+			buffer.append(s);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		flushInternal();
+		super.close();
+	}
+
+	private void flushInternal() {
+		message.print(new AttributedString(buffer.toString(), style));
+		buffer = new StringBuilder();
+	}
+
+}

--- a/src/main/java/org/springframework/cli/command/BuildCommands.java
+++ b/src/main/java/org/springframework/cli/command/BuildCommands.java
@@ -185,7 +185,7 @@ public class BuildCommands {
 	}
 
 	private @NotNull Stream<String[]> getPlugins(BuildSystem buildSystem) {
-		var rows = container.plugins(buildSystem).stream().map(x -> {
+		var rows = container.plugins(buildSystem).stream().sorted().map(x -> {
 			var desc = container.get(x, buildSystem);
 			return new String[] { x, desc.id(), desc.description(), buildSystem.name() };
 		});

--- a/src/main/java/org/springframework/cli/command/BuildCommands.java
+++ b/src/main/java/org/springframework/cli/command/BuildCommands.java
@@ -16,29 +16,50 @@
 
 package org.springframework.cli.command;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
 
 import com.canonical.devpackspring.build.BuildSystem;
+import com.canonical.devpackspring.build.PluginDescriptor;
 import com.canonical.devpackspring.build.PluginDescriptorContainer;
+import com.canonical.devpackspring.build.PluginRunner;
 import org.jetbrains.annotations.NotNull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cli.util.IoUtils;
 import org.springframework.cli.util.TerminalMessage;
 import org.springframework.shell.command.annotation.Command;
+import org.springframework.shell.command.annotation.Option;
 import org.springframework.shell.component.flow.ComponentFlow;
+import org.springframework.shell.component.flow.DefaultSelectItem;
+import org.springframework.shell.component.flow.ResultMode;
+import org.springframework.shell.component.flow.SelectItem;
+import org.springframework.shell.component.support.Nameable;
 import org.springframework.shell.table.ArrayTableModel;
 import org.springframework.shell.table.BorderStyle;
 import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableBuilder;
 import org.springframework.shell.table.TableModel;
 
-@Command(command = "build", group = "Build Plugins")
+@Command
 public class BuildCommands {
+
+	public static final String PLUGIN_CONFIGURATION = "SPRING_CLI_BUILD_COMMANDS_PLUGIN_CONFIGURATION";
+
+	private static final String PLUGIN_PARAMETER_ID = "plugin";
+
+	private static final String PLUGIN_NAME = "Plugin";
+
+	private static final String TASK_PARAMETER_ID = "task";
+
+	private static final String TASK_NAME = "Task";
 
 	private final Path workingDir;
 
@@ -55,13 +76,103 @@ public class BuildCommands {
 		this.componentFlowBuilder = componentFlowBuilder;
 		this.workingDir = IoUtils.getWorkingDirectory();
 		this.container = null;
-		try (InputStream stream = getClass()
-			.getResourceAsStream("/com/canonical/devpackspring/plugin-configuration.yaml")) {
+		try (InputStream stream = getPluginConfiguration()) {
 			this.container = new PluginDescriptorContainer(new InputStreamReader(stream));
 		}
 	}
 
-	@Command(command = "list", description = "List build plugins supported by the snap")
+	private InputStream getPluginConfiguration() throws IOException {
+		String pluginConfigurationFile = System.getenv(PLUGIN_CONFIGURATION);
+		if (pluginConfigurationFile == null) {
+			pluginConfigurationFile = System.getProperty(PLUGIN_CONFIGURATION);
+		}
+		if (pluginConfigurationFile != null) {
+			return new FileInputStream(pluginConfigurationFile);
+		}
+		return getClass().getResourceAsStream("/com/canonical/devpackspring/plugin-configuration.yaml");
+	}
+
+	@Command(command = "plugin", description = "Run a build plugin for the project")
+	public void run(@Option(description = "plugin name") String plugin,
+			@Option(description = "task/goal") String command, @Option(description = "project path") Path projectPath)
+			throws IOException {
+		PluginRunner runner = new PluginRunner((projectPath != null) ? projectPath : workingDir);
+		BuildSystem buildSystem = runner.detectBuildSystem();
+
+		PluginDescriptor desc = null;
+		if (plugin != null) {
+			desc = container.get(plugin, buildSystem);
+		}
+
+		boolean needCommandSelect = (desc == null);
+		if (desc != null && command != null) {
+			final String cmd = command;
+			needCommandSelect = Arrays.stream(desc.tasks()).filter(x -> x.equals(cmd)).findAny().isEmpty();
+		}
+
+		if (desc == null) {
+			List<SelectItem> items = container.plugins(buildSystem)
+				.stream()
+				.map(x -> (SelectItem) new DefaultSelectItem(x, x, true, false))
+				.toList();
+			if (items.isEmpty()) {
+				throw new IllegalArgumentException("No plugins defined.\n");
+			}
+
+			// @formatter: off
+			ComponentFlow wizard = componentFlowBuilder.clone()
+				.reset()
+				.withSingleItemSelector(PLUGIN_PARAMETER_ID)
+				.name(PLUGIN_NAME)
+				.resultValue(plugin)
+				.resultMode(ResultMode.ACCEPT)
+				.selectItems(items)
+				.defaultSelect(items.getFirst().name())
+				.sort(Comparator.comparing(Nameable::getName))
+				.and()
+				.build();
+			plugin = wizard.run().getContext().get(PLUGIN_PARAMETER_ID);
+			desc = container.get(plugin, buildSystem);
+		}
+
+		if (needCommandSelect) {
+			List<SelectItem> tasks = Arrays.stream(desc.tasks())
+				.map(x -> (SelectItem) new DefaultSelectItem(x, x, true, false))
+				.toList();
+
+			// @formatter: off
+			ComponentFlow wizard = componentFlowBuilder.clone()
+				.reset()
+				.withSingleItemSelector(TASK_PARAMETER_ID)
+				.name(TASK_NAME)
+				.resultValue(command)
+				.resultMode(ResultMode.ACCEPT)
+				.selectItems(tasks)
+				.defaultSelect(desc.defaultTask())
+				.sort(Comparator.comparing(Nameable::getName))
+				.and()
+				.build();
+			command = wizard.run().getContext().get(TASK_PARAMETER_ID);
+		}
+
+		if (!runner.run(buildSystem, desc, command, terminalMessage)) {
+			StringBuilder message = new StringBuilder();
+			message.append("Failed to run plugin ");
+			message.append(desc.id());
+			if (desc.version() != null) {
+				message.append(":");
+				message.append(desc.version());
+			}
+			if (command != null) {
+				message.append(" ");
+				message.append(command);
+			}
+			message.append("\n");
+			throw new RuntimeException(message.toString());
+		}
+	}
+
+	@Command(command = "list-plugins", description = "List supported build plugins")
 	public Table list() {
 		// TODO: check build system and print applicable plugins
 		var header = Stream.<String[]>of(new String[] { "Name", "Id", "Description", "Build System" });

--- a/src/main/java/org/springframework/cli/command/BuildCommands.java
+++ b/src/main/java/org/springframework/cli/command/BuildCommands.java
@@ -127,7 +127,7 @@ public class BuildCommands {
 				.resultValue(plugin)
 				.resultMode(ResultMode.ACCEPT)
 				.selectItems(items)
-				.defaultSelect(items.getFirst().name())
+				.defaultSelect(items.iterator().next().name())
 				.sort(Comparator.comparing(Nameable::getName))
 				.and()
 				.build();

--- a/src/main/resources/com/canonical/devpackspring/apply-plugin-deps.gradle.kts
+++ b/src/main/resources/com/canonical/devpackspring/apply-plugin-deps.gradle.kts
@@ -1,0 +1,10 @@
+initscript {
+    repositories {
+        // configure the list of repositories
+        %s
+    }
+    dependencies {
+        // configure the list of classpath dependencies
+        classpath("%s")
+    }
+}

--- a/src/main/resources/com/canonical/devpackspring/apply-plugin.gradle.kts
+++ b/src/main/resources/com/canonical/devpackspring/apply-plugin.gradle.kts
@@ -1,0 +1,12 @@
+allprojects {
+    afterEvaluate {
+        if (name == rootProject.name) {
+            if (!plugins.hasPlugin("%s")) { // plugin id
+                apply<%s>() // plugin class name
+                plugins.withId("%s") {
+                    %s
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/com/canonical/devpackspring/plugin-configuration.yaml
+++ b/src/main/resources/com/canonical/devpackspring/plugin-configuration.yaml
@@ -1,3 +1,21 @@
+format:
+  gradle:
+    id: io.spring.javaformat
+    version: 0.0.43
+    class-name: io.spring.javaformat.gradle.SpringJavaFormatPlugin
+    default-task: format
+    description: Formats source code
+    tasks:
+      - format
+    repository: gradlePluginPortal()
+    classpath: "io.spring.javaformat:io.spring.javaformat.gradle.plugin:0.0.43"
+  maven:
+    id: io.spring.javaformat:spring-javaformat-maven-plugin
+    version: 0.0.43
+    default-task: :apply
+    description: Formats source code
+    tasks:
+      - :apply
 rockcraft:
   gradle:
     id: io.github.rockcrafters.rockcraft
@@ -15,9 +33,11 @@ rockcraft:
       - build-build-rock
       - push-rock
       - push-build-rock
+    # Gradle Kotlin DSL snippet to configure the defaults
     default-configuration: |
-      rockcraft {
-      }
+          configure<com.canonical.rockcraft.builder.RockcraftOptions> {
+              setTargetRelease(21)
+          }
   maven:
     id: io.github.rockcrafters:rockcraft-maven-plugin
     version: 1.0.0
@@ -25,6 +45,7 @@ rockcraft:
     description: |
       Plugin for rock image generation
     tasks:
+      - install :create-rock
       - install :create-rock :build-rock
       - :create-build-rock
       - install :create-rock :build-rock :push-rock

--- a/src/test/java/org/springframework/cli/command/BuildCommandTests.java
+++ b/src/test/java/org/springframework/cli/command/BuildCommandTests.java
@@ -17,15 +17,27 @@
 package org.springframework.cli.command;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cli.support.IntegrationTestSupport;
+import org.springframework.cli.support.MockConfigurations;
 import org.springframework.cli.util.StubTerminalMessage;
 import org.springframework.shell.table.Table;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class BuildCommandTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(MockConfigurations.MockBaseConfig.class);
 
 	@Test
 	public void testListPlugins() throws IOException {
@@ -35,6 +47,65 @@ public class BuildCommandTests {
 		String plugins = ret.render(80);
 		assertThat(plugins).contains("rockcraft");
 		assertThat(plugins).contains("io.github.rockcrafters.rockcraft");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "gradle-kotlin", "gradle-groovy" })
+	public void testRunGradlePlugin(String project, final @TempDir Path workingDir) {
+		Path projectPath = Path.of("test-data").resolve("projects").resolve(project);
+		IntegrationTestSupport.installInWorkingDirectory(projectPath, workingDir);
+		contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run(context -> {
+			assertThat(context).hasSingleBean(BuildCommands.class);
+			BuildCommands commands = context.getBean(BuildCommands.class);
+			// we can specify the task to run
+			commands.run("rockcraft", "create-rock", workingDir);
+			assertThat(workingDir.resolve("build/rockcraft.yaml")).exists();
+			// default task works
+			commands.run("rockcraft", null, workingDir);
+			assertThat(workingDir.resolve("build/rock")).exists();
+		});
+	}
+
+	@Test
+	public void testCustomPluginContainer(final @TempDir Path workingDir) throws IOException {
+		Path projectPath = Path.of("test-data").resolve("projects").resolve("gradle-groovy");
+
+		IntegrationTestSupport.installInWorkingDirectory(projectPath, workingDir);
+		Path pluginsYaml = workingDir.resolve("plugins.yaml");
+		System.setProperty(BuildCommands.PLUGIN_CONFIGURATION, pluginsYaml.toString());
+
+		Files.write(pluginsYaml,
+				getClass().getResourceAsStream("/com/canonical/devpackspring/build/test-custom-plugin.yaml")
+					.readAllBytes());
+
+		contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run(context -> {
+			assertThat(context).hasSingleBean(BuildCommands.class);
+			BuildCommands commands = context.getBean(BuildCommands.class);
+			Files.writeString(workingDir.resolve("src/main/java/com/example/demo/Test.java"), """
+					package com.example.demo;
+
+					public class Test {public Test() {} }
+
+					""");
+			// format can be run
+			assertThatCode(() -> commands.run("format-me", null, workingDir)).doesNotThrowAnyException();
+		});
+	}
+
+	@Test
+	public void testRunMavenPlugin(final @TempDir Path workingDir) {
+		Path projectPath = Path.of("test-data").resolve("projects").resolve("rest-service");
+		IntegrationTestSupport.installInWorkingDirectory(projectPath, workingDir);
+		contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run(context -> {
+			assertThat(context).hasSingleBean(BuildCommands.class);
+			BuildCommands commands = context.getBean(BuildCommands.class);
+			// we can specify the task to run
+			commands.run("rockcraft", "install :create-rock", workingDir);
+			assertThat(workingDir.resolve("target/rockcraft.yaml")).exists();
+			// default task works
+			commands.run("rockcraft", null, workingDir);
+			assertThat(workingDir.resolve("target/rock")).exists();
+		});
 	}
 
 }

--- a/src/test/java/org/springframework/cli/command/BuildCommandTests.java
+++ b/src/test/java/org/springframework/cli/command/BuildCommandTests.java
@@ -97,7 +97,6 @@ public class BuildCommandTests {
 			// format can be run
 			assertThatCode(() -> commands.run("format-me", null, workingDir)).doesNotThrowAnyException();
 		});
-		System.setProperty(BuildCommands.PLUGIN_CONFIGURATION, null);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cli/command/BuildCommandTests.java
+++ b/src/test/java/org/springframework/cli/command/BuildCommandTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,6 +39,12 @@ public class BuildCommandTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withUserConfiguration(MockConfigurations.MockBaseConfig.class);
+
+	@AfterEach
+	public void tearDown() {
+		// clear plugin configuration property
+		System.clearProperty(BuildCommands.PLUGIN_CONFIGURATION);
+	}
 
 	@Test
 	public void testListPlugins() throws IOException {
@@ -90,6 +97,7 @@ public class BuildCommandTests {
 			// format can be run
 			assertThatCode(() -> commands.run("format-me", null, workingDir)).doesNotThrowAnyException();
 		});
+		System.setProperty(BuildCommands.PLUGIN_CONFIGURATION, null);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cli/command/BuildCommandTests.java
+++ b/src/test/java/org/springframework/cli/command/BuildCommandTests.java
@@ -23,8 +23,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cli.support.IntegrationTestSupport;
@@ -56,10 +54,9 @@ public class BuildCommandTests {
 		assertThat(plugins).contains("io.github.rockcrafters.rockcraft");
 	}
 
-	@ParameterizedTest
-	@ValueSource(strings = { "gradle-kotlin", "gradle-groovy" })
-	public void testRunGradlePlugin(String project, final @TempDir Path workingDir) {
-		Path projectPath = Path.of("test-data").resolve("projects").resolve(project);
+	@Test
+	public void testRunGradlePlugin(final @TempDir Path workingDir) {
+		Path projectPath = Path.of("test-data").resolve("projects").resolve("gradle-kotlin");
 		IntegrationTestSupport.installInWorkingDirectory(projectPath, workingDir);
 		contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run(context -> {
 			assertThat(context).hasSingleBean(BuildCommands.class);

--- a/src/test/java/org/springframework/cli/support/MockConfigurations.java
+++ b/src/test/java/org/springframework/cli/support/MockConfigurations.java
@@ -17,6 +17,7 @@
 package org.springframework.cli.support;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +32,7 @@ import org.jline.terminal.Terminal;
 import org.mockito.Mockito;
 
 import org.springframework.cli.command.BootCommands;
+import org.springframework.cli.command.BuildCommands;
 import org.springframework.cli.command.CommandCommands;
 import org.springframework.cli.command.RoleCommands;
 import org.springframework.cli.command.SpecialCommands;
@@ -105,6 +107,11 @@ public class MockConfigurations {
 				}
 
 			};
+		}
+
+		@Bean
+		BuildCommands buildCommands() throws IOException {
+			return new BuildCommands(TerminalMessage.noop(), null);
 		}
 
 		@Bean

--- a/src/test/resources/com/canonical/devpackspring/build/test-custom-plugin.yaml
+++ b/src/test/resources/com/canonical/devpackspring/build/test-custom-plugin.yaml
@@ -1,0 +1,12 @@
+format-me:
+  gradle:
+    id: io.spring.javaformat
+    version: 0.0.41
+    class-name: io.spring.javaformat.gradle.SpringJavaFormatPlugin
+    default-task: format
+    description: Formats source code
+    tasks:
+      - format
+    repository: gradlePluginPortal()
+    classpath: "io.spring.javaformat:io.spring.javaformat.gradle.plugin:0.0.43"
+


### PR DESCRIPTION
The PR renames `build list-plugins` to `list-plugins`. The sample output
```
┌─────────┬───────────────────────────────────────────────────┬────────────────────────────────┬────────────┐
│Name     │Id                                                 │Description                     │Build System│
├─────────┼───────────────────────────────────────────────────┼────────────────────────────────┼────────────┤
│format   │io.spring.javaformat                               │Formats source code             │gradle      │
├─────────┼───────────────────────────────────────────────────┼────────────────────────────────┼────────────┤
│rockcraft│io.github.rockcrafters.rockcraft                   │Plugin for rock image generation│gradle      │
├─────────┼───────────────────────────────────────────────────┼────────────────────────────────┼────────────┤
│format   │io.spring.javaformat:spring-javaformat-maven-plugin│Formats source code             │maven       │
├─────────┼───────────────────────────────────────────────────┼────────────────────────────────┼────────────┤
│rockcraft│io.github.rockcrafters:rockcraft-maven-plugin      │Plugin for rock image generation│maven       │
└─────────┴───────────────────────────────────────────────────┴────────────────────────────────┴────────────┘
```

This PR implements 'plugin' command to run configured build plugins using spring-cli. 

```
 $java -jar ~/git/spring-cli/build/libs/spring-cli-0.10.0-SNAPSHOT.jar plugin
? Plugin format
? Task format
> Task :formatMain
> Task :formatTest UP-TO-DATE
> Task :format

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 8s
2 actionable tasks: 1 executed, 1 up-to-date
```

The plugins are configured using yaml configuration file.  The configuration file location is set in the order of preference:
- `SPRING_CLI_BUILD_COMMANDS_PLUGIN_CONFIGURATION` environment variable, 
- `SPRING_CLI_BUILD_COMMANDS_PLUGIN_CONFIGURATION` Java property
- hardcoded resource location


